### PR TITLE
Downcase repo name on push dockerimage action

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -44,7 +44,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-
+      - name: downcase REPO
+        run: |
+          echo "REPO=$(echo ${{github.repository}} | tr '[:upper:]' '[:lower:]')" >>${GITHUB_ENV}
+          
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
@@ -54,7 +57,6 @@ jobs:
           context: ./image-updater/source-code
           file: ./image-updater/source-code/Dockerfile
           push: true
-          tags: ghcr.io/${{ github.repository }}:${{ inputs.docker_tag }}
-
+          tags: ghcr.io/${{ env.REPO }}:${{ inputs.docker_tag }}
 
 


### PR DESCRIPTION
The actions fail to push due to the registry name is not lowercase. 