### PR TITLE
fix(docker-publish): handle Uppercased chars repository

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,9 +19,6 @@ on:
 env:
   # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io
-  # github.repository as <account>/<repo>
-  IMAGE_NAME: ${{ github.repository }}
-
 
 jobs:
   build-push:
@@ -34,8 +31,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-
-
+  
+      - name: Set Env
+        run: |
+          echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
@@ -54,7 +53,4 @@ jobs:
           context: ./image-updater/source-code
           file: ./image-updater/source-code/Dockerfile
           push: true
-          tags: ghcr.io/${{ github.repository }}:${{ inputs.docker_tag }}
-
-
-
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.docker_tag }}


### PR DESCRIPTION
Hello 👋 

I noticed the workflow does not work with repositories that contains uppercased chars.

I propose this PR which does the following:

- remove the `IMAGE_NAME` from the hardcoded env variables
- create an intermadiate step which get the repository and lowercase it, then push it to the `GITHUB_ENV`
- Finally, use this env variable `IMAGE_NAME` in the `Build and push Docker image` step
- (Bonus), use the `REGISTRY` env as well in the step, (ghcr.io was harcoded) 

POC => https://github.com/Nico385412/gitops-cert-level-2-examples/actions/runs/3554828803